### PR TITLE
feat: throw a separate error when a process terminates via signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 If the spawned process exits with a non-zero code, an `ExitCodeError` is thrown with the original
 command, code, `stdout`, and `stderr` as properties.
 
+If the spawned process is terminated by a signal on non-Windows platforms, an `ExitSignalError` is
+thrown with the original command, signal name, `stdout`, and `stderr` as properties.
+
 ## Extra Options
 
 * `logger`: a `Function` such as `console.log` or `debug(name)` to log some information

--- a/test/fixtures/killed-by-signal.ts
+++ b/test/fixtures/killed-by-signal.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import process from "process";
+
+process.kill(process.pid, "SIGKILL");

--- a/test/index.ts
+++ b/test/index.ts
@@ -26,19 +26,21 @@ test("throws an error when it cannot find an executable", async (t) => {
   t.is(originalError.syscall, "spawn does-not-exist");
 });
 
-test("throws an error when the spawned process is terminated via a signal", async (t) => {
-  const error = (await t.throwsAsync(
-    spawn(path.resolve(__dirname, "..", "node_modules", ".bin", "ts-node"), [
-      path.resolve(__dirname, "fixtures", "killed-by-signal.ts"),
-    ]),
-    {
-      instanceOf: ExitSignalError,
-      message: /^Command terminated via a signal/,
-    }
-  )) as ExitSignalError;
+if (process.platform !== "win32") {
+  test("throws an error when the spawned process is terminated via a signal", async (t) => {
+    const error = (await t.throwsAsync(
+      spawn(path.resolve(__dirname, "..", "node_modules", ".bin", "ts-node"), [
+        path.resolve(__dirname, "fixtures", "killed-by-signal.ts"),
+      ]),
+      {
+        instanceOf: ExitSignalError,
+        message: /^Command terminated via a signal/,
+      }
+    )) as ExitSignalError;
 
-  t.is(error.signal, "SIGKILL");
-});
+    t.is(error.signal, "SIGKILL");
+  });
+}
 
 test("updateErrorCallback modifies the exception", async (t) => {
   await t.throwsAsync(

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,4 +1,5 @@
-import { CrossSpawnError, spawn } from "../src";
+import { CrossSpawnError, ExitSignalError, spawn } from "../src";
+import path from "path";
 import test from "ava";
 
 test("returns stdout", async (t) => {
@@ -23,6 +24,20 @@ test("throws an error when it cannot find an executable", async (t) => {
 
   t.is(originalError.code, "ENOENT");
   t.is(originalError.syscall, "spawn does-not-exist");
+});
+
+test("throws an error when the spawned process is terminated via a signal", async (t) => {
+  const error = (await t.throwsAsync(
+    spawn(path.resolve(__dirname, "..", "node_modules", ".bin", "ts-node"), [
+      path.resolve(__dirname, "fixtures", "killed-by-signal.ts"),
+    ]),
+    {
+      instanceOf: ExitSignalError,
+      message: /^Command terminated via a signal/,
+    }
+  )) as ExitSignalError;
+
+  t.is(error.signal, "SIGKILL");
 });
 
 test("updateErrorCallback modifies the exception", async (t) => {


### PR DESCRIPTION
## Description of Change

Turns out when a process is terminated by a signal, `code` is `null` (which is unsurprising).

## Checklist

* [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-promise/blob/master/CONTRIBUTING.md) for this project.
* [x] The changes are appropriately documented (if applicable).
* [x] The changes have sufficient test coverage (if applicable).
* [x] The testsuite passes successfully on my local machine (if applicable).
