### PR TITLE
refactor: fix typecheck due to change in @types/node

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,9 @@ export async function spawn(
       if (code === 0) {
         resolve(stdout);
       } else if (code === null) {
-        reject(new ExitSignalError(cmd, args, signal, stdout, stderr));
+        // Why: assume signal is not null if code is null
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        reject(new ExitSignalError(cmd, args, signal!, stdout, stderr));
       } else {
         reject(new ExitCodeError(cmd, args, code, stdout, stderr));
       }


### PR DESCRIPTION
## Description of Change

A recent `@types/node` change removed `| null` from the `signal` parameter of `SignalExitError`, which is causing CI errors.

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-promise/blob/master/CONTRIBUTING.md) for this project.
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).
