### PR TITLE
feat!: require Node.js 12 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macOS-latest, ubuntu-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - name: Fix git checkout line endings

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "prettier": "^2.0.1",
     "source-map-support": "^0.5.16",
     "ts-node": "^10.0.0",
-    "typedoc": "^0.20.0-beta.24",
+    "typedoc": "^0.21.2",
     "typescript": "~4.2.4"
   },
   "ava": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/cross-spawn": "^6.0.1",
+    "@types/node": "^15.14.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "^4.0.1",
     "ava": "^3.3.0",
@@ -46,7 +47,7 @@
     "pinst": "^2.1.6",
     "prettier": "^2.0.1",
     "source-map-support": "^0.5.16",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.0.0",
     "typedoc": "^0.20.0-beta.24",
     "typescript": "~4.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -15,11 +15,8 @@
     "coverage": "nyc --reporter=lcov --reporter=text ava",
     "docs": "typedoc src/index.ts",
     "lint": "prettier --check . && eslint --ext .ts .",
-    "prepare": "npm run build",
-    "test": "yarn lint && yarn ava",
-    "postinstall": "husky install",
-    "prepublishOnly": "pinst --disable",
-    "postpublish": "pinst --enable"
+    "prepare": "husky install && yarn build",
+    "test": "yarn lint && yarn ava"
   },
   "files": [
     "dist"
@@ -41,10 +38,9 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-tsdoc": "^0.2.5",
-    "husky": "^6.0.0",
+    "husky": "^7.0.0",
     "lint-staged": "^11.0.0",
     "nyc": "^15.0.0",
-    "pinst": "^2.1.6",
     "prettier": "^2.0.1",
     "source-map-support": "^0.5.16",
     "ts-node": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-tsdoc": "^0.2.5",
     "husky": "^6.0.0",
-    "lint-staged": "^10.0.7",
+    "lint-staged": "^11.0.0",
     "nyc": "^15.0.0",
     "pinst": "^2.1.6",
     "prettier": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Mark Lee",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12.13.0"
   },
   "scripts": {
     "ava": "ava",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "source-map-support": "^0.5.16",
     "ts-node": "^10.0.0",
     "typedoc": "^0.21.2",
-    "typescript": "~4.2.4"
+    "typescript": "~4.3.5"
   },
   "ava": {
     "extensions": [


### PR DESCRIPTION
## Description of Change

BREAKING CHANGE: Drops support for Node.js < 12.13.0

Technically, there are no code changes or production dependency changes to necessitate this, but several of the devDependencies now require Node.js 12 (LTS). This module only commits to supporting Node.js versions that are officially supported.

Also:

* adds a CI job to test against Node.js 16
* upgrades all `devDependencies`.

## Checklist

- [x] I have read the [contribution documentation](https://github.com/malept/cross-spawn-promise/blob/master/CONTRIBUTING.md) for this project.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).
